### PR TITLE
Fix issues with structural schema in CRD

### DIFF
--- a/config/core/300-githubsource.yaml
+++ b/config/core/300-githubsource.yaml
@@ -62,6 +62,7 @@ metadata:
       ]
 spec:
   group: sources.knative.dev
+  version: v1alpha1
   names:
     categories:
     - all
@@ -88,6 +89,7 @@ spec:
       JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
           properties:
@@ -150,49 +152,37 @@ spec:
             serviceAccountName:
               type: string
             sink:
-              anyOf:
-              - type: object
-                description: "the destination that should receive events."
-                properties:
-                  ref:
-                    type: object
-                    description: "a reference to a Kubernetes object from which to retrieve the target URI."
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                    properties:
-                      apiVersion:
-                        type: string
-                        minLength: 1
-                      kind:
-                        type: string
-                        minLength: 1
-                      name:
-                        type: string
-                        minLength: 1
-                  uri:
-                    type: string
-                    description: "the target URI. If ref is provided, this must be relative URI reference."
-              - type: object
-                description: "DEPRECATED: a reference to a Kubernetes object from which to retrieve the target URI."
-                required:
-                - apiVersion
-                - kind
-                - name
-                properties:
-                  apiVersion:
-                    type: string
-                    minLength: 1
-                  kind:
-                    type: string
-                    minLength: 1
-                  name:
-                    type: string
-                    minLength: 1
-                  uri:
-                    type: string
-                    description: "the target URI. If ref is provided, this must be relative URI reference."
+              description: The destination of events received from webhooks.
+              type: object
+              properties:
+                ref:
+                  description: Reference to an addressable Kubernetes object
+                    to be used as the destination of events.
+                  type: object
+                  properties:
+                    apiVersion:
+                      type: string
+                      minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    namespace:
+                      type: string
+                      minLength: 1
+                    name:
+                      type: string
+                      minLength: 1
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                uri:
+                  description: URI to use as the destination of events.
+                  type: string
+                  format: uri
+              oneOf:
+              - required: [ref]
+              - required: [uri]
           required:
           - ownerAndRepository
           - eventTypes
@@ -228,5 +218,4 @@ spec:
             webhookIDKey:
               type: string
           type: object
-  version: v1alpha1
 

--- a/config/core/300-githubsource.yaml
+++ b/config/core/300-githubsource.yaml
@@ -93,15 +93,15 @@ spec:
       properties:
         spec:
           properties:
-            accessToken:
-              properties:
-                secretKeyRef:
-                  type: object
-              type: object
-            ceOverrides:
-              type: object
-              description: "Defines overrides to control modifications of the event sent to the sink."
+            ownerAndRepository:
+              description: Reference to the GitHub repository to receive events
+                from, in the format user/repository.
+              type: string
+              minLength: 1
             eventTypes:
+              description: List of webhooks to enable on the selected GitHub
+                repository.
+              type: array
               items:
                 enum:
                 - check_suite
@@ -140,15 +140,60 @@ spec:
                 - watch
                 type: string
               minItems: 1
-              type: array
-            ownerAndRepository:
-              minLength: 1
-              type: string
-            secretToken:
+            accessToken:
+              description: Access token for the GitHub API.
+              type: object
               properties:
                 secretKeyRef:
+                  description: A reference to a Kubernetes Secret object
+                    containing a GitHub access token.
                   type: object
+                  properties:
+                    name:
+                      description: The name of the Kubernetes Secret object
+                        which contains the GitHub access token.
+                      type: string
+                    key:
+                      description: The key which contains the GitHub access
+                        token within the Kubernetes Secret object referenced by
+                        name.
+                      type: string
+                  required:
+                  - name
+                  - key
+            secretToken:
+              description: Arbitrary token used to validate requests to
+                webhooks.
               type: object
+              properties:
+                secretKeyRef:
+                  description: A reference to a Kubernetes Secret object
+                    containing the webhook token.
+                  type: object
+                  properties:
+                    name:
+                      description: The name of the Kubernetes Secret object
+                        which contains the webhook token.
+                      type: string
+                    key:
+                      description: The key which contains the webhook token
+                        within the Kubernetes Secret object referenced by name.
+                      type: string
+                  required:
+                  - name
+                  - key
+            ceOverrides:
+              type: object
+              description: Defines overrides to control modifications of the
+                event sent to the sink.
+              properties:
+                extensions:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    minLength: 1
+              required:
+              - extensions
             serviceAccountName:
               type: string
             sink:


### PR DESCRIPTION
Fixes #89

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix issues in the OpenAPI structural schema reported by the API server

Tested against Kubernetes v1.17.13 and v1.20.0. The source is working as expected and the previous errors are gone.