### PR TITLE
Leverage shared Main for dependency injection

### DIFF
--- a/cmd/mt_receive_adapter/main.go
+++ b/cmd/mt_receive_adapter/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,28 +17,17 @@ limitations under the License.
 package main
 
 import (
-	"log"
-
-	"knative.dev/pkg/controller"
-
+	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/signals"
 
 	githubadapter "knative.dev/eventing-github/pkg/mtadapter"
-	"knative.dev/eventing/pkg/adapter/v2"
-	"knative.dev/pkg/injection"
-	"knative.dev/pkg/injection/sharedmain"
 )
 
+const component = "githubsource"
+
 func main() {
-	cfg := sharedmain.ParseAndGetConfigOrDie()
-
 	ctx := signals.NewContext()
-	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
+	ctx = adapter.WithController(ctx, githubadapter.NewController(component))
 
-	log.Println("Starting informers...")
-	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
-		log.Fatalf("Failed to start informers: %v", err)
-	}
-
-	adapter.MainWithContext(ctx, "githubsource", githubadapter.NewEnvConfig, githubadapter.NewAdapter)
+	adapter.MainWithContext(ctx, component, githubadapter.NewEnvConfig, githubadapter.NewAdapter)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github/v31 v31.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.16.0
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
 	gopkg.in/go-playground/webhooks.v5 v5.13.0

--- a/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ package v1alpha1
 import (
 	"fmt"
 
-	"knative.dev/pkg/webhook/resourcesemantics"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/webhook/resourcesemantics"
 )
 
 // Check that GitHubSource can be validated and can be defaulted.
@@ -107,12 +107,14 @@ const (
 	gitHubEventSourcePrefix = "https://github.com"
 )
 
-// GitHubEventType returns the GitHub CloudEvent type value.
+// GitHubEventType returns an event type emitted by a GitHubSource suitable for
+// the value of a CloudEvent's "type" context attribute.
 func GitHubEventType(ghEventType string) string {
 	return fmt.Sprintf("%s.%s", gitHubEventTypePrefix, ghEventType)
 }
 
-// GitHubEventSource returns the GitHub CloudEvent source value.
+// GitHubEventSource returns a unique representation of a GitHubSource suitable
+// for the value of a CloudEvent's "source" context attribute.
 func GitHubEventSource(ownerAndRepo string) string {
 	return fmt.Sprintf("%s/%s", gitHubEventSourcePrefix, ownerAndRepo)
 }

--- a/pkg/mtadapter/adapter_test.go
+++ b/pkg/mtadapter/adapter_test.go
@@ -1,7 +1,7 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
-Licensed under the Apache License, Veroute.on 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
@@ -440,7 +440,7 @@ func newTestAdapter(t *testing.T, ce cloudevents.Client) *gitHubAdapter {
 		EnvConfig: adapter.EnvConfig{
 			Namespace: "default",
 		},
-		EnvPort: "8080",
+		EnvPort: 8080,
 	}
 	ctx, _ := pkgtesting.SetupFakeContext(t)
 	logger := zap.NewExample().Sugar()

--- a/pkg/mtadapter/controller_test.go
+++ b/pkg/mtadapter/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package mtadapter
 import (
 	"testing"
 
-	. "knative.dev/pkg/reconciler/testing"
+	"github.com/stretchr/testify/assert"
+	rt "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection clients and informers
 	_ "knative.dev/eventing-github/pkg/client/injection/informers/sources/v1alpha1/githubsource/fake"
@@ -28,11 +29,10 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	ctx, _ := SetupFakeContext(t)
+	const testComponent = "test_component"
 
-	c := NewController(ctx, nil)
+	ctx, _ := rt.SetupFakeContext(t)
 
-	if c == nil {
-		t.Fatal("Expected NewController to return a non-nil value")
-	}
+	c := NewController(testComponent)(ctx, &gitHubAdapter{})
+	assert.NotNil(t, c)
 }

--- a/pkg/mtadapter/router/router_test.go
+++ b/pkg/mtadapter/router/router_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mtadapter
+package router
 
 import (
 	"io/ioutil"
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	adaptertesting "knative.dev/eventing/pkg/adapter/v2/test"
 	logtesting "knative.dev/pkg/logging/testing"
 
 	"knative.dev/eventing-github/test/lib"
@@ -33,11 +32,10 @@ import (
 
 func TestGitHubServer(t *testing.T) {
 	logger := logtesting.TestLogger(t)
-	ce := adaptertesting.NewTestClient()
 
 	objects := []runtime.Object{resources.NewGitHubSourceV1Alpha1("valid", "path")}
 	lister := lib.NewListers(objects).GetGithubSourceLister()
-	handler := NewRouter(logger, lister, ce)
+	handler := New(logger, lister)
 
 	s := httptest.NewServer(handler)
 	defer s.Close()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,6 +265,7 @@ github.com/sirupsen/logrus
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.6.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/tsenart/vegeta/v12 v12.8.4


### PR DESCRIPTION
## Proposed Changes

A pretty significant code clean up that leverages the shared Main for dependency injection from the adapter to the controller, instead of setting up informers manually. This results in a cleaner initialization flow.

In a nutshell:
1. let injection.Main initialize informers
2. initialize the Router inside the adapter's constructor
3. and finally, consume that Router in the controller's constructor. 

I also did a few other minor refactorings along the way, such as returning wrapped errors with an explicit context whenever possible, shortening some variable names which type is already explicit, consolidating Godocs, etc.

---

_A note, since this subproject doesn't have e2e tests_:

Changes were tested manually as follows:
* Deploy using `ko apply -f config/mt-github/`
* Create a GitHubSource object with event-display as the event sink
* Confirm that events are sent to `/namespace/name` and forwarded to the sink