### PR TITLE
Simplify contract between MT reconciler and adapter

### DIFF
--- a/pkg/mtadapter/controller_test.go
+++ b/pkg/mtadapter/controller_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	rt "knative.dev/pkg/reconciler/testing"
+	rectesting "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection clients and informers
 	_ "knative.dev/eventing-github/pkg/client/injection/informers/sources/v1alpha1/githubsource/fake"
@@ -31,7 +31,7 @@ import (
 func TestNew(t *testing.T) {
 	const testComponent = "test_component"
 
-	ctx, _ := rt.SetupFakeContext(t)
+	ctx, _ := rectesting.SetupFakeContext(t)
 
 	c := NewController(testComponent)(ctx, &gitHubAdapter{})
 	assert.NotNil(t, c)

--- a/pkg/mtadapter/githubsource.go
+++ b/pkg/mtadapter/githubsource.go
@@ -18,29 +18,20 @@ package mtadapter
 
 import (
 	"context"
-	"fmt"
-
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	corev1 "k8s.io/api/core/v1"
-	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 
 	"knative.dev/eventing-github/pkg/apis/sources/v1alpha1"
 	githubsourcereconciler "knative.dev/eventing-github/pkg/client/injection/reconciler/sources/v1alpha1/githubsource"
-	"knative.dev/eventing-github/pkg/common"
-	"knative.dev/eventing-github/pkg/mtadapter/router"
 )
 
 // Reconciler manages HTTP routes based on the GitHubSource objects in the
 // controller's cache.
 type Reconciler struct {
-	secrGetter clientcorev1.SecretsGetter
-	ceClient   cloudevents.Client
-	router     *router.Router
+	mtAdapter MTAdapter
 }
 
 // Check that Reconciler implements reconciler.Interface.
@@ -56,21 +47,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.GitHubSour
 			"GitHubSource is not ready yet. Skipping adapter configuration"))
 	}
 
-	return r.reconcile(ctx, src)
-}
-
-func (r *Reconciler) reconcile(ctx context.Context, src *v1alpha1.GitHubSource) error {
-	secretCli := r.secrGetter.Secrets(src.Namespace)
-	secretToken, err := common.SecretFrom(ctx, secretCli, src.Spec.SecretToken.SecretKeyRef)
-	if err != nil {
-		return fmt.Errorf("reading token from Secret: %w", err)
-	}
-
-	ceSrc := v1alpha1.GitHubEventSource(src.Spec.OwnerAndRepository)
-	handler := common.NewHandler(r.ceClient, src.Status.SinkURI.String(), ceSrc, secretToken, logging.FromContext(ctx))
-
-	path := fmt.Sprintf("/%s/%s", src.Namespace, src.Name)
-	r.router.Register(src.Name, src.Namespace, path, handler)
-
-	return nil
+	return r.mtAdapter.RegisterHandlerFor(ctx, src)
 }

--- a/pkg/mtadapter/githubsource_test.go
+++ b/pkg/mtadapter/githubsource_test.go
@@ -26,7 +26,6 @@ import (
 
 	"knative.dev/pkg/apis"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 	rectesting "knative.dev/pkg/reconciler/testing"
 
@@ -75,9 +74,13 @@ func TestGitHubSource(t *testing.T) {
 			ctx, _ := rectesting.SetupFakeContext(t)
 			ctx, kubeClient := fakekubeclient.With(ctx, newSecret())
 
-			reconciler := &Reconciler{
+			mtAdapter := &gitHubAdapter{
 				secrGetter: kubeClient.CoreV1(),
-				router:     router.New(logging.FromContext(ctx), nil),
+				router:     router.New(nil),
+			}
+
+			reconciler := &Reconciler{
+				mtAdapter: mtAdapter,
 			}
 
 			event := reconciler.ReconcileKind(ctx, test.source)

--- a/pkg/mtadapter/router/router.go
+++ b/pkg/mtadapter/router/router.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"sync"
 
-	"go.uber.org/zap"
 	"knative.dev/eventing-github/pkg/client/listers/sources/v1alpha1"
 )
 
@@ -35,8 +34,6 @@ type keyedHandler struct {
 // Router is a GitHub webhook router which delegates webhook events received
 // over HTTP to sub-routers.
 type Router struct {
-	logger *zap.SugaredLogger
-
 	routersMu sync.RWMutex
 	routers   map[string]keyedHandler
 
@@ -47,9 +44,8 @@ type Router struct {
 var _ http.Handler = (*Router)(nil)
 
 // New returns a new Router.
-func New(logger *zap.SugaredLogger, lister v1alpha1.GitHubSourceLister) *Router {
+func New(lister v1alpha1.GitHubSourceLister) *Router {
 	return &Router{
-		logger:  logger,
 		routers: make(map[string]keyedHandler),
 		lister:  lister,
 	}

--- a/pkg/mtadapter/router/router_test.go
+++ b/pkg/mtadapter/router/router_test.go
@@ -24,20 +24,17 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	logtesting "knative.dev/pkg/logging/testing"
 
 	"knative.dev/eventing-github/test/lib"
 	"knative.dev/eventing-github/test/lib/resources"
 )
 
 func TestGitHubServer(t *testing.T) {
-	logger := logtesting.TestLogger(t)
-
 	objects := []runtime.Object{resources.NewGitHubSourceV1Alpha1("valid", "path")}
 	lister := lib.NewListers(objects).GetGithubSourceLister()
-	handler := New(logger, lister)
+	router := New(lister)
 
-	s := httptest.NewServer(handler)
+	s := httptest.NewServer(router)
 	defer s.Close()
 
 	// Not Found
@@ -50,7 +47,7 @@ func TestGitHubServer(t *testing.T) {
 	}
 
 	// Registered and in the indexer
-	handler.Register("valid", "path", "/valid/path", &fakeHandler{
+	router.Register("valid", "path", "/valid/path", &fakeHandler{
 		handler: sinkAccepted,
 	})
 
@@ -64,7 +61,7 @@ func TestGitHubServer(t *testing.T) {
 	}
 
 	// Registered but not in the indexer
-	handler.Register("valid-not-in-cache", "path", "/valid-not-in-cache/path", &fakeHandler{
+	router.Register("valid-not-in-cache", "path", "/valid-not-in-cache/path", &fakeHandler{
 		handler: sinkAccepted,
 	})
 


### PR DESCRIPTION
Follow up to #106

## Proposed Changes

- Pass MTAdapter interface as a dependency to the reconciler.

This interface allows the multi-tenant adapter to expose methods the reconciler can call while reconciling a source object. It simplifies the contract between MT reconciler and adapter and results in less convoluted code (separation of concerns, avoid direct access to private fields).