### PR TITLE
Add missing CRD

### DIFF
--- a/config/core/300-githubsource.yaml
+++ b/config/core/300-githubsource.yaml
@@ -96,6 +96,9 @@ spec:
           properties:
             spec:
               properties:
+                githubAPIURL:
+                  description: URL for enterprise GitHub
+                  type: string
                 ownerAndRepository:
                   description: Reference to the GitHub repository to receive events
                     from, in the format user/repository.


### PR DESCRIPTION
Fixes #351 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add missing githubAPIURL property


**Release Note**

```release-note
- 🐛 Fix bug: It was not possible to use Github eventing on enterprise GitHub since githubAPIURL was not on the CRD.
```

